### PR TITLE
Makefile fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.idea
+qccx
+progs.dat
+/meta
+/build
+qccx-src/*.o
+*.qc
+*.src
+src/quake/progdefs.h

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 #
 # Makefile for Metamorphism; (C) 2007 Lon Hohberger
 # Updated by Patrick Baggett 2011
+# Updated by Kevin Quillen 2021
 
-COPYDIR ?= ~/Quake/meta/
+COPYDIR ?= ./build/meta/
 QCC ?= qccx
 
 all: $(QCC) progs.dat
@@ -27,6 +28,7 @@ progs.dat: $(QCC) force_look
 	-rm progs.dat
 	make -C src/common CFLAGS="-I../../include -DQUAKE -DGAME_CTF"
 	make -C src/quake QCC=../../$(QCC) CFLAGS="-I../../include -DQUAKE -DGAME_CTF"
+	mkdir -p $(COPYDIR)
 	cp progs.dat $(COPYDIR)
 
 force_look:


### PR DESCRIPTION
Fix up the Makefile to dump the build to the current directory. Add a gitignore file to ignore IDE and generated files.